### PR TITLE
fix chunked

### DIFF
--- a/cmd/http-json/main.go
+++ b/cmd/http-json/main.go
@@ -285,7 +285,7 @@ func executeCheck(event *corev2.Event) (int, error) {
 	}
 
 	// will responds [] as empty response
-	if int(resp.ContentLength) <= 2 {
+	if len(body) <= 2 {
 		fmt.Printf("empty response: %s\n", err)
 		return sensu.CheckStateCritical, nil
 	}


### PR DESCRIPTION
issue: 
```bash
go run ./cmd/http-json \                                                                                                                16:00:07                          
    --url 'https://api.fastly.com/public-ip-list' \                                                                                                                          
    --query '.addresses | contains(["23.235.32.0/20","43.249.72.0/22","103.244.50.0/24","103.245.222.0/23","103.245.224.0/24","104.156.80.0/20","140.248.64.0/18","140.248.1 
  28.0/17","146.75.0.0/17","151.101.0.0/16","157.52.64.0/18","167.82.0.0/17","167.82.128.0/20","167.82.160.0/20","167.82.224.0/20","172.111.64.0/18","185.31.16.0/22","199.2 
  7.72.0/21","199.232.0.0/16"])' \                                                                                                                                           
    --expression '== true'                                                                                                                                                   
  empty response: %!s(<nil>)                                                                                                                                                 
  exit status 2 
```

Line 288 checks resp.ContentLength to detect empty responses, but many servers (including Fastly) use chunked transfer encoding and don't set a  Content-Length header — so resp.ContentLength is -1, which is <= 2, triggering the false "empty response" path.

